### PR TITLE
refactor url api, et methode pour utile pour construire l'url. #patch

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     logging.info("HOSTNAME : %s", HOSTNAME)
     logging.info("NB_PROCESS : %s", NB_PROCESS)
 
-    REQ_NB_SESSIONS = worker.send_request("nodes", "GET")
+    REQ_NB_SESSIONS = worker.send_request(worker.URL_API + "nodes", "GET")
 
     NODES = REQ_NB_SESSIONS.json()
     NB_SESSION = 0
@@ -118,6 +118,12 @@ if __name__ == "__main__":
                       "(ex: python client.py -s _MonSuffixe).")
         sys.exit(1)
 
-    worker.exec_multiprocess(HOSTNAME, NB_PROCESS, ARGS.tags, False)
+    worker.exec_multiprocess(
+        worker.URL_API,
+        HOSTNAME,
+        NB_PROCESS,
+        ARGS.tags,
+        False
+    )
 
     logging.info("Fin du client GPAO")

--- a/client/worker.py
+++ b/client/worker.py
@@ -33,22 +33,27 @@ URL_API = (
 )
 
 
+def build_url_api(hostname: str, port="8080"):
+    """construit l'url"""
+    return f"http://{hostname}:{port}/api/"
+
+
 def send_request(url, mode, json=None, str_thread_id=None):
     """ Fonction executant les requetes http """
     success = False
-    logging.debug("%s : %s : %s%s", str_thread_id, mode, URL_API, url)
+    logging.debug("%s : %s : %s", str_thread_id, mode, url)
     while not success:
         try:
             if mode == "GET":
-                req = requests.get(URL_API+url, timeout=60)
+                req = requests.get(url, timeout=60)
                 req.raise_for_status()
                 return req
             if mode == "PUT":
-                req = requests.put(URL_API+url, timeout=60)
+                req = requests.put(url, timeout=60)
                 req.raise_for_status()
                 return req
             if mode == "POST":
-                req = requests.post(URL_API+url, json=json, timeout=60)
+                req = requests.post(url, json=json, timeout=60)
                 req.raise_for_status()
                 return req
         except requests.exceptions.Timeout:
@@ -80,14 +85,14 @@ def get_free_space_gb(dirname):
     return space_available
 
 
-def read_stdout_process(proc: subprocess.Popen, id_job, str_thread_id, command):
+def read_stdout_process(url_api:str, proc: subprocess.Popen, id_job, str_thread_id, command):
     """ Lecture de la sortie console """
     last_flush = time.time()
     command_str = "Commande : "+str(command)+"\n\n"
 
     url_tmp = "job/" + str(id_job) + "/appendLog"
 
-    send_request(url_tmp,
+    send_request(url_api + url_tmp,
                  "POST",
                  json={"log": command_str},
                  str_thread_id=str_thread_id)
@@ -121,7 +126,7 @@ def read_stdout_process(proc: subprocess.Popen, id_job, str_thread_id, command):
             if realtime_output:
                 url_tmp = "job/" + str(id_job) + "/appendLog"
 
-                send_request(url_tmp,
+                send_request(url_api + url_tmp,
                              "POST",
                              json={"log": realtime_output},
                              str_thread_id=str_thread_id)
@@ -131,7 +136,7 @@ def read_stdout_process(proc: subprocess.Popen, id_job, str_thread_id, command):
 
             url_tmp = "job/" + str(id_job) + "/appendLog"
 
-            send_request(url_tmp,
+            send_request(url_api + url_tmp,
                          "POST",
                          json={"log": realtime_output},
                          str_thread_id=str_thread_id)
@@ -140,7 +145,7 @@ def read_stdout_process(proc: subprocess.Popen, id_job, str_thread_id, command):
             last_flush = time.time()
 
 
-def launch_command(job, str_thread_id, shell, working_dir):
+def launch_command(url_api: str, job, str_thread_id, shell, working_dir):
     """ Lancement d'une ligne de commande """
     id_job = job["id"]
     command = job["command"]
@@ -165,7 +170,7 @@ def launch_command(job, str_thread_id, shell, working_dir):
             universal_newlines=True,
             cwd=working_dir,
         ) as proc:
-            read_stdout_process(proc, id_job, str_thread_id, command)
+            read_stdout_process(url_api, proc, id_job, str_thread_id, command)
             return_code = proc.poll()
             status = "done"
     except subprocess.CalledProcessError as ex:
@@ -184,8 +189,22 @@ def launch_command(job, str_thread_id, shell, working_dir):
     return id_job, return_code, status, error_message
 
 
+def is_enought_free_space_on_disk(working_dir):
+    """return True is there is space on the disk"""
+    free_gb = get_free_space_gb(working_dir)
+    if free_gb < MIN_AVAILABLE_SPACE:
+        logging.warning(
+            "Espace disque insuffisant : %s/%s",
+            free_gb,
+            MIN_AVAILABLE_SPACE
+            )
+        return False
+    return True
+
+
 def process(parameters, id_thread):
     """ Traitement pour un thread """
+    url_api = parameters["url_api"]
     str_thread_id = "[" + str(id_thread) + "]"
     id_session = -1
     # AB : Il faut passer shell=True sous windows
@@ -201,7 +220,7 @@ def process(parameters, id_thread):
             if parameters["tags"]:
                 url += "&tags=" + parameters["tags"]
 
-            req = send_request(url, "PUT", str_thread_id=str_thread_id)
+            req = send_request(url_api + url, "PUT", str_thread_id=str_thread_id)
 
             id_session = req.json()[0]["id"]
             logging.info("%s : working dir (%s) id_session (%s)",
@@ -211,23 +230,16 @@ def process(parameters, id_thread):
                 logging.info("%s : Ce thread devient actif", str_thread_id)
                 host = parameters["hostname"]
 
-                send_request("node/setNbActive?host=" + host + "&limit=10",
+                send_request(url_api + "node/setNbActive?host=" + host + "&limit=10",
                              "POST",
                              str_thread_id=str_thread_id)
 
             while True:
                 # on verifie l'espace disponible dans le dossier de travail
-                free_gb = get_free_space_gb(working_dir)
                 req = None
-                if free_gb < MIN_AVAILABLE_SPACE:
-                    logging.warning(
-                        "Espace disque insuffisant : %s/%s",
-                        free_gb,
-                        MIN_AVAILABLE_SPACE
-                        )
-                else:
+                if is_enought_free_space_on_disk(working_dir):
                     url_tmp = "job/ready?id_session=" + str(id_session)
-                    req = send_request(url_tmp,
+                    req = send_request(url_api + url_tmp,
                                        "GET",
                                        str_thread_id=str_thread_id)
                 if req and req.json():
@@ -237,7 +249,7 @@ def process(parameters, id_thread):
                         status,
                         error_message,
                     ) = launch_command(
-                        req.json()[0], str_thread_id, shell, working_dir
+                        url_api, req.json()[0], str_thread_id, shell, working_dir
                     )
 
                     logging.info("%s : Maj du job: %s, code_retour: %s, "
@@ -251,7 +263,7 @@ def process(parameters, id_thread):
                                "&status=" + str(status) +
                                "&returnCode=" + str(return_code))
 
-                    req = send_request(url_tmp,
+                    req = send_request(url_api + url_tmp,
                                        "POST",
                                        json={"log": error_message},
                                        str_thread_id=str_thread_id)
@@ -274,14 +286,14 @@ def process(parameters, id_thread):
     except KeyboardInterrupt:
         logging.info("%s : On demande au process de s'arreter", str_thread_id)
 
-        req = send_request("session/close?id=" + str(id_session),
+        send_request(url_api + "session/close?id=" + str(id_session),
                            "POST",
                            str_thread_id=str_thread_id)
 
     logging.info("%s : Fin du thread", str_thread_id)
 
 
-def exec_multiprocess(hostname, nb_process, tags, mode_exec_and_quit):
+def exec_multiprocess(url_api, hostname, nb_process, tags, mode_exec_and_quit):
     """ Execution du multiprocess """
     if platform.system() == "Windows":
         if nb_process > 60:
@@ -291,7 +303,8 @@ def exec_multiprocess(hostname, nb_process, tags, mode_exec_and_quit):
     with multiprocessing.Pool(nb_process) as pool:
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        parameters = {'hostname': hostname,
+        parameters = {'url_api': url_api,
+                      'hostname': hostname,
                       'tags': tags,
                       'mode_exec_and_quit': mode_exec_and_quit}
 

--- a/test/test_print_loop.py
+++ b/test/test_print_loop.py
@@ -39,4 +39,4 @@ def test_1_create_gpao():
 
 def test_3_execute_gpao_client_multithreaded():
 
-    worker.exec_multiprocess("test_client", 1, "", True)
+    worker.exec_multiprocess(worker.URL_API, "test_client", 1, "", True)

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -48,4 +48,4 @@ def test_2_execute_gpao_client():
 
 def test_3_execute_gpao_client_multithreaded():
 
-    worker.exec_multiprocess("test_client", 3, "", True)
+    worker.exec_multiprocess(worker.URL_API, "test_client", 3, "", True)


### PR DESCRIPTION
- refactor url api
  - permet d'utiliser la méthode worker.exec_multiprocess avec l'url_api en parametre (sans regarder l'environnement)
  - cote client, ça ne change pas, on regarde l'environnement, comme avant ce commit
- ajout d'une méthode utile pour construire l'url 